### PR TITLE
Set up the rhevm class, add the rhevm shell init and host info function

### DIFF
--- a/hypervisor/virt/rhevm/rhevmcli.py
+++ b/hypervisor/virt/rhevm/rhevmcli.py
@@ -20,6 +20,13 @@ class RHVMCLI:
         self.ssh = SSHConnect(self.server, user=self.ssh_user, pwd=self.ssh_pwd)
 
     def rhevm_shell_config(self, admin_server, admin_user, admin_passwd):
+        """
+        config the rhevm shell, connect to the rhevm server
+        :param admin_server: ip for the server
+        :param admin_user: username for the account
+        :param admin_passwd: password for the account
+        :return:
+        """
         api_url = f"{admin_server}/api"
         ca_file = "/etc/pki/ovirt-engine/ca.pem"
         options = "insecure = False\n" \

--- a/hypervisor/virt/rhevm/rhevmcli.py
+++ b/hypervisor/virt/rhevm/rhevmcli.py
@@ -5,29 +5,61 @@ from hypervisor import FailException
 from hypervisor import logger
 from hypervisor.ssh import SSHConnect
 
-class RHVMCLI:
-    def __init__(self, server, ssh_user, ssh_pwd):
+
+class RHEVMCLI:
+    def __init__(self, server, ssh_user, ssh_pwd, *admin_option):
         """
-        Collect rhevm information, provide Guest add/delete/start/stop/suspend/resume functions
-        via ovirt-shell Command line
-        :param server: the ip for the rhevm server
-        :param ssh_user: the ssh user for the rhevm server
-        :param ssh_pwd: the ssh password for the rhevm server
+        Collect RHEVM information, provide Guest add/delete/start/stop/suspend/resume functions
+        via ovirt-shell Command line following 'https://access.redhat.com/documentation/en-us/
+        red_hat_virtualization/4.1/html-single/rhevm_shell_guide/index'
+        :param server: the ip for the RHEVM server
+        :param ssh_user: the ssh user for the RHEVM server
+        :param ssh_pwd: the ssh password for the RHEVM server
         """
         self.server = server
         self.ssh_user = ssh_user
         self.ssh_pwd = ssh_pwd
         self.ssh = SSHConnect(self.server, user=self.ssh_user, pwd=self.ssh_pwd)
+        if not self.rhevm_shell_connection():
+            self.rhevm_shell_config(*admin_option)
 
-    def rhevm_shell_config(self, admin_server, admin_user, admin_passwd):
+    def rhevm_url(self):
         """
-        config the rhevm shell, connect to the rhevm server
-        :param admin_server: ip for the server
-        :param admin_user: username for the account
-        :param admin_passwd: password for the account
+        Get the URL to the Red Hat Virtualization Manager's REST API.
+        This takes the form of https://[server]/ovirt-engine/api.
         :return:
         """
-        api_url = f"{admin_server}/api"
+        ret, output = self.ssh.runcmd('hostname')
+        if not ret and output is not None and output is not "":
+            hostname = output.strip()
+            return f"https://{hostname}:443/ovirt-engine"
+        else:
+            raise FailException(f"Failed to get url for RHEVM {self.server}")
+
+    def rhevm_shell_connection(self):
+        """
+        Check if the oVirt manager could be reached.
+        :return:
+        """
+        cmd = f"echo | ovirt-shell -c -E  'ping'"
+        ret, output = self.ssh.runcmd(cmd)
+        if not ret and "success" in output:
+            logger.info(f"Succeeded to connect RHEVM({self.server}) shell")
+            return True
+        else:
+            logger.info(f"Failed to connect RHEVM({self.server}) shell")
+            return False
+
+    def rhevm_shell_config(self, admin_user, admin_pwd):
+        """
+        The URL, user name, certificate authority file, and password for connecting to the RHEVM
+        can be configured in the .ovirtshellrc file. Config the RHEVM shell.
+        :param admin_user: The user name and directory service domain of the user attempting
+        access to the RHEVM. This takes the form of [username]@[domain].
+        :param admin_pwd: The password for the user attempting access to the RHEVM.
+        :return:
+        """
+        api_url = f"{self.rhevm_url()}/api"
         ca_file = "/etc/pki/ovirt-engine/ca.pem"
         options = "insecure = False\n" \
                   "no_paging = False\n" \
@@ -36,18 +68,12 @@ class RHVMCLI:
         rhevm_shellrc = '/root/.ovirtshellrc'
         cmd = f"echo -e '[ovirt-shell]\n" \
             f"username = {admin_user}\n" \
-            f"password = {admin_passwd}\n" \
+            f"password = {admin_pwd}\n" \
             f"ca_file = {ca_file}\n" \
             f"url = {api_url}\n" \
             f"{options}' > {rhevm_shellrc}"
         self.ssh.runcmd(cmd)
         self.ssh.runcmd("ovirt-aaa-jdbc-tool user unlock admin")
-        cmd = f"ovirt-shell -c -E  'ping'"
-        ret, output = self.ssh.runcmd(cmd)
-        if not ret and "success" in output:
-            logger.info(f"Succeeded to config rhevm({self.server}) shell")
-        else:
-            raise FailException(f"Failed to config rhevm({self.server}) shell")
 
     def info(self):
         """
@@ -56,7 +82,7 @@ class RHVMCLI:
         """
         cmd = "ovirt-shell -c -E 'list hosts' | grep '^name' | awk -F ':' '{print $2}'"
         ret, output = self.ssh.runcmd(cmd)
-        if not ret and output is not None and output != "":
+        if not ret and output is not None and output is not "":
             hosts = output.strip().split('\n')
         else:
             hosts = list()

--- a/hypervisor/virt/rhevm/rhevmcli.py
+++ b/hypervisor/virt/rhevm/rhevmcli.py
@@ -1,0 +1,49 @@
+import json
+import re
+
+from hypervisor import FailException
+from hypervisor import logger
+from hypervisor.ssh import SSHConnect
+
+class RHVMCLI:
+    def __init__(self, server, ssh_user, ssh_pwd):
+        """
+        Collect rhevm information, provide Guest add/delete/start/stop/suspend/resume functions
+        via ovirt-shell Command line
+        :param server: the ip for the rhevm server
+        :param ssh_user: the ssh user for the rhevm server
+        :param ssh_pwd: the ssh password for the rhevm server
+        """
+        self.server = server
+        self.ssh_user = ssh_user
+        self.ssh_pwd = ssh_pwd
+        self.ssh = SSHConnect(self.server, user=self.ssh_user, pwd=self.ssh_pwd)
+
+    def rhevm_shell_config(self, admin_server, admin_user, admin_passwd):
+        api_url = "{0}/api".format(admin_server)
+        ca_file = "/etc/pki/ovirt-engine/ca.pem"
+        options = "insecure = False\nno_paging = False\nfilter = False\ntimeout = -1"
+        cmd = "echo -e '[ovirt-shell]\nusername = {0}\npassword = {1}\nca_file = {2}\nurl = {3}\n{4}' > {5}"\
+                .format(admin_user, admin_passwd, ca_file, api_url, options, "/root/.ovirtshellrc")
+        self.ssh.runcmd(cmd)
+        self.ssh.runcmd("ovirt-aaa-jdbc-tool user unlock admin")
+        cmd = "{0} -c -E  'ping'".format("ovirt-shell")
+        ret, output = self.ssh.runcmd(cmd)
+        if ret == 0 and "success" in output:
+            logger.info("Succeeded to config rhevm({0}) shell".format(self.server))
+        else:
+            raise FailException("Failed to config rhevm({0}) shell".format(self.server))
+
+    def info(self):
+        """
+        Get the VMhost info
+        :return: the VMHosts info
+        """
+        cmd = "ovirt-shell -c -E 'list hosts' | grep '^name' | awk -F ':' '{print $2}'"
+        ret, output = self.ssh.runcmd(cmd)
+        if ret == 0 and output is not None and output != "":
+            hosts = output.strip().split('\n')
+        else:
+            hosts = list()
+        logger.info(f"Get RHEVM Host: {hosts}")
+        return hosts

--- a/hypervisor/virt/rhevm/rhevmcli.py
+++ b/hypervisor/virt/rhevm/rhevmcli.py
@@ -22,17 +22,24 @@ class RHVMCLI:
     def rhevm_shell_config(self, admin_server, admin_user, admin_passwd):
         api_url = "{0}/api".format(admin_server)
         ca_file = "/etc/pki/ovirt-engine/ca.pem"
-        options = "insecure = False\nno_paging = False\nfilter = False\ntimeout = -1"
-        cmd = "echo -e '[ovirt-shell]\nusername = {0}\npassword = {1}\nca_file = {2}\nurl = {3}\n{4}' > {5}"\
-                .format(admin_user, admin_passwd, ca_file, api_url, options, "/root/.ovirtshellrc")
+        options = "insecure = False\n" \
+                  "no_paging = False\n" \
+                  "filter = False\n" \
+                  "timeout = -1"
+        rhevm_shellrc = '/root/.ovirtshellrc'
+        cmd = f"echo -e '[ovirt-shell]\n" \
+            f"username = {admin_user}\n" \
+            f"password = {admin_passwd}\n" \
+            f"ca_file = {ca_file}\n" \
+            f"url = {api_url}\n{options}' > {rhevm_shellrc}"
         self.ssh.runcmd(cmd)
         self.ssh.runcmd("ovirt-aaa-jdbc-tool user unlock admin")
-        cmd = "{0} -c -E  'ping'".format("ovirt-shell")
+        cmd = f"ovirt-shell -c -E  'ping'"
         ret, output = self.ssh.runcmd(cmd)
-        if ret == 0 and "success" in output:
-            logger.info("Succeeded to config rhevm({0}) shell".format(self.server))
+        if not ret and "success" in output:
+            logger.info(f"Succeeded to config rhevm({self.server}) shell")
         else:
-            raise FailException("Failed to config rhevm({0}) shell".format(self.server))
+            raise FailException(f"Failed to config rhevm({self.server}) shell")
 
     def info(self):
         """
@@ -41,7 +48,7 @@ class RHVMCLI:
         """
         cmd = "ovirt-shell -c -E 'list hosts' | grep '^name' | awk -F ':' '{print $2}'"
         ret, output = self.ssh.runcmd(cmd)
-        if ret == 0 and output is not None and output != "":
+        if not ret and output is not None and output != "":
             hosts = output.strip().split('\n')
         else:
             hosts = list()

--- a/hypervisor/virt/rhevm/rhevmcli.py
+++ b/hypervisor/virt/rhevm/rhevmcli.py
@@ -20,7 +20,7 @@ class RHVMCLI:
         self.ssh = SSHConnect(self.server, user=self.ssh_user, pwd=self.ssh_pwd)
 
     def rhevm_shell_config(self, admin_server, admin_user, admin_passwd):
-        api_url = "{0}/api".format(admin_server)
+        api_url = f"{admin_server}/api"
         ca_file = "/etc/pki/ovirt-engine/ca.pem"
         options = "insecure = False\n" \
                   "no_paging = False\n" \
@@ -31,7 +31,8 @@ class RHVMCLI:
             f"username = {admin_user}\n" \
             f"password = {admin_passwd}\n" \
             f"ca_file = {ca_file}\n" \
-            f"url = {api_url}\n{options}' > {rhevm_shellrc}"
+            f"url = {api_url}\n" \
+            f"{options}' > {rhevm_shellrc}"
         self.ssh.runcmd(cmd)
         self.ssh.runcmd("ovirt-aaa-jdbc-tool user unlock admin")
         cmd = f"ovirt-shell -c -E  'ping'"


### PR DESCRIPTION
**Description**
Set up the format for the rhevm-shell file and add host info function

**Test Result**
Configed the rhevmclirc file:
```
[hkx303@kuhuang hypervisor]$ pytest test.py -k test_rhevm -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/hypervisor-builder/hypervisor
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item                                                                             

test.py [2021-07-02 17:12:10] - [ssh.py] - INFO: >>> echo | ovirt-shell -c -E  'ping'
[2021-07-02 17:12:12] - [ssh.py] - INFO: <<< stdout
[oVirt shell (connected)]# ping

success: oVirt manager could be reached OK.



[2021-07-02 17:12:12] - [rhevmcli.py] - INFO: Succeeded to connect RHEVM(10.73.x.xxx) shell
[2021-07-02 17:12:12] - [ssh.py] - INFO: >>> ovirt-shell -c -E 'list hosts' | grep '^name' | awk -F ':' '{print $2}'
[2021-07-02 17:12:13] - [ssh.py] - INFO: <<< stdout
 bootp-xx-x-xxx.rhts.eng.pek2.redhat.com

[2021-07-02 17:12:13] - [rhevmcli.py] - INFO: Get RHEVM Host: ['bootp-xx-x-xxx.rhts.eng.pek2.redhat.com']
['bootp-xx-x-xxx.rhts.eng.pek2.redhat.com']

===================================== 1 passed in 3.73s ======================================
```
Not configed yet:
```
[hkx303@kuhuang hypervisor]$ pytest test.py -k test_rhevm -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/hypervisor-builder/hypervisor
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item                                                                             

test.py [2021-07-02 17:11:53] - [ssh.py] - INFO: >>> echo | ovirt-shell -c -E  'ping'
[2021-07-02 17:11:53] - [ssh.py] - INFO: <<< stderr


[2021-07-02 17:11:53] - [rhevmcli.py] - INFO: Failed to connect RHEVM(10.73.x.xxx) shell
[2021-07-02 17:11:54] - [ssh.py] - INFO: >>> hostname
[2021-07-02 17:11:54] - [ssh.py] - INFO: <<< stdout
bootp-xx-x-xxx.rhts.eng.pek2.redhat.com

[2021-07-02 17:11:54] - [ssh.py] - INFO: >>> echo -e '[ovirt-shell]
username = admin@internal
password = admin
ca_file = /etc/pki/ovirt-engine/ca.pem
url = https://bootp-xx-x-xxx.rhts.eng.pek2.redhat.com:443/ovirt-engine/api
insecure = False
no_paging = False
filter = False
timeout = -1' > /root/.ovirtshellrc
[2021-07-02 17:11:55] - [ssh.py] - INFO: <<< stdout

[2021-07-02 17:11:55] - [ssh.py] - INFO: >>> ovirt-aaa-jdbc-tool user unlock admin
[2021-07-02 17:11:57] - [ssh.py] - INFO: <<< stdout
updating user admin...
user updated successfully

[2021-07-02 17:11:57] - [ssh.py] - INFO: >>> ovirt-shell -c -E 'list hosts' | grep '^name' | awk -F ':' '{print $2}'
[2021-07-02 17:11:59] - [ssh.py] - INFO: <<< stdout
 bootp-xx-x-xxx.rhts.eng.pek2.redhat.com

[2021-07-02 17:11:59] - [rhevmcli.py] - INFO: Get RHEVM Host: ['bootp-xx-x-xxx.rhts.eng.pek2.redhat.com']

===================================== 1 passed in 6.97s ======================================
```


