### PR TITLE
Search the specific guest attributes from host by ovirt-shell

### DIFF
--- a/hypervisor/virt/rhevm/rhevmcli.py
+++ b/hypervisor/virt/rhevm/rhevmcli.py
@@ -1,6 +1,3 @@
-import json
-import re
-
 from hypervisor import FailException
 from hypervisor import logger
 from hypervisor.ssh import SSHConnect
@@ -102,7 +99,7 @@ class RHEVMCLI:
         cluster_id = self.get_rhevm_info("vm", guest_name, 'cluster-id')
         guest_msgs = {
             'guest_name': guest_name,
-            'guest_ip': self.get_guest_ip_by_mac(guest_name, host_ip, host_user, host_pwd),
+            'guest_ip': self.get_guest_ip(guest_name, host_ip, host_user, host_pwd),
             'guest_uuid': self.get_rhevm_info("vm", guest_name, 'id'),
             'guest_state': self.get_rhevm_info("vm", guest_name, 'status-state'),
             'vdsm_uuid': host_id,
@@ -130,8 +127,9 @@ class RHEVMCLI:
             return result
         else:
             logger.info(f"Failed to get rhevm {object_type} ({object_id}) {value}")
+            return None
 
-    def get_guest_ip_by_mac(self, guest_name, host_ip, host_user, host_pwd):
+    def get_guest_ip(self, guest_name, host_ip, host_user, host_pwd):
         """
         Get guest ip by mac
         :param guest_name: name for the specific guest
@@ -183,3 +181,4 @@ class RHEVMCLI:
             return mac_addr
         else:
             logger.info(f"Failed to check rhevm({self.server}) guest mac")
+            return None


### PR DESCRIPTION
**Descriptiono**
Added `guest_search()` , `get_rhevm_info()` and guest_ip related function

**Test Result**
```
>>>    cli = RHEVMCLI(server, ssh_user, ssh_pwd, admin_user, admin_pwd)
>>>    print(cli.guest_search(guest_name, host_ip, host_user, host_pwd))
{'guest_name': '8.3_Server_x86_64', 'guest_ip': '10.73.5.227', 'guest_uuid': 'e27cd702-0e74-4ddf-8755-c2a04207372a', 'guest_state': 'up', 'vdsm_uuid': 'd7dc6478-d0e5-4c22-a61c-7a76d5507de4', 'vdsm_hwuuid': '5CEB2C71-0C8F-434C-93A1-9E1D61AF9B09', 'vdsm_hostname': 'bootp-73-5-203.rhts.eng.pek2.redhat.com', 'vdsm_version': 'vdsm-4.30.51-1.el7ev', 'vdsm_cpu': '2', 'vdsm_cluster': 'Default'}
```
