### PR TITLE
Fix the error when getting the gateway for hypervisor

### DIFF
--- a/hypervisor/virt/libvirt/libvirtcli.py
+++ b/hypervisor/virt/libvirt/libvirtcli.py
@@ -176,7 +176,7 @@ class LibvirtCLI:
         :param host_pwd: the ssh password for the libvirt host
         :return: the gateway for host
         """
-        cmd = f"ip route | grep {host_ip}"
+        cmd = f"ip route | grep {host_ip} | grep /"
         ret, output = self.ssh.runcmd(cmd)
         if not ret and output is not None and output != "":
             output = output.strip().split(" ")


### PR DESCRIPTION
**Description**
See details in https://github.com/VirtwhoQE/virtwho-ci/pull/262

**Test Result**
```
def test_libvirt():
    server = '10.73.xxx.xxx'
    username = 'root'
    password = 'pwd'
    guest_name = '8.7_Server_x86_64'
    from hypervisor.virt.libvirt.libvirtcli import LibvirtCLI
    cli = LibvirtCLI(server, username, password)
    print(cli.guest_search(guest_name))
```


```
[hkx303@kuhuang hypervisor]$ pytest test.py -k test_libvirt -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/hypervisor-builder/hypervisor
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 4 items / 3 deselected / 1 selected  

{'guest_name': '8.7_Server_x86_64', 'guest_ip': '10.73.131.242', 'guest_uuid': 'c37492db-42ea-47d6-b6f3-36f8cfa92b8a', 'guest_state': 'running', 'host_uuid': '5eaf21df-b345-4aa9-8cca-d8db2c31ce58', 'host_version': '6.2.0', 'host_cpu': '2'}
```


