### PR TITLE
powercli.py: correct to get the esx_cpu

### DIFF
--- a/hypervisor/virt/esx/powercli.py
+++ b/hypervisor/virt/esx/powercli.py
@@ -163,7 +163,7 @@ class PowerCLI:
             'esx_hostname': output["VMHost"]["Name"],
             'esx_version': output["VMHost"]["Version"],
             'esx_state': output["VMHost"]["PowerState"],
-            'esx_cpu': str(output["NumCpu"]),
+            'esx_cpu': str(output["VMHost"]["NumCpu"]),
             'esx_cluster': output["VMHost"]["Parent"]
         }
         if uuid_info:


### PR DESCRIPTION
`'esx_cpu': str(output["NumCpu"])` -> `'esx_cpu': str(output["VMHost"]["NumCpu"])`