### PR TITLE
ssh/runcmd(): add if_stdout=False

### DIFF
--- a/hypervisor/ssh.py
+++ b/hypervisor/ssh.py
@@ -71,9 +71,10 @@ class SSHConnect:
         sftp = paramiko.SFTPClient.from_transport(transport)
         return sftp, transport
 
-    def runcmd(self, cmd):
+    def runcmd(self, cmd, if_stdout=False):
         """Executes SSH command on remote hostname.
         :param str cmd: The command to run
+        :param str if_stdout: default to return the stderr
         """
         ssh = self._connect()
         logger.info(">>> {}".format(cmd))
@@ -81,7 +82,7 @@ class SSHConnect:
         code = stdout.channel.recv_exit_status()
         stdout, stderr = stdout.read(), stderr.read()
         ssh.close()
-        if not stderr:
+        if if_stdout or not stderr:
             logger.info("<<< stdout\n{}".format(stdout.decode()))
             return code, stdout.decode()
         else:

--- a/hypervisor/virt/libvirt/libvirtcli.py
+++ b/hypervisor/virt/libvirt/libvirtcli.py
@@ -185,7 +185,7 @@ class LibvirtCLI:
         if gateway and guest_mac:
             option = "grep 'Nmap scan report for' | grep -Eo '([0-9]{1,3}[\.]){3}[0-9]{1,3}'| tail -1"
             cmd = f"nmap -sP -n {gateway} | grep -i -B 2 {guest_mac} | {option}"
-            ret, output = self.ssh.runcmd(cmd)
+            ret, output = self.ssh.runcmd(cmd, if_stdout=True)
             if not ret and output is not None and output != "":
                 guest_ip = output.strip()
                 logger.info(f"Succeeded to get libvirt guest ip ({guest_ip})")


### PR DESCRIPTION
**Description**
When get the libvirt guest ip, sometime it fails with error `RTTVAR has grown to over 2.3 seconds, decreasing to 2.0` due to the network delay. Now added a new param `if_stdout=False` to the runcmd() function, so we can directly get the stdout, which will be the correct ip address.

**Test Result - PASS**
```
% python3 -m pytest -v tests/others/test_hypervisors_state.py -k 'libvirt' 
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 7 items / 6 deselected / 1 selected                                                                                         

tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_libvirt PASSED                                         [100%]

================================================== 1 passed, 6 deselected in 21.27s ===================================================
```