### PR TITLE
Add ssh-agent fallback support to SSH class

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -48,7 +48,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MegaLinter reports
           path: |

--- a/README.rst
+++ b/README.rst
@@ -54,5 +54,7 @@ These hypervisors will be supported:
    -  Connection
          -  ncli/acli
          -  API
+
    -  Collect nutanix information
+
    -  Guest add/delete/start/stop/suspend/resume

--- a/hypervisor/virt/esx/README.md
+++ b/hypervisor/virt/esx/README.md
@@ -1,23 +1,22 @@
 # Hypervisor-builder: vCenter
+
 Hyperivosr-builder tool supports the vcenter hypervisor by PowerCLI Commands
 following the doc:
 [VMware PowerCLI Documentation](https://developer.vmware.com/powercli/)
-
 
 Provide functions:
 - Collect vcenter information
 - Host search/add/delete/restart/start/stop
 - Guest search/add/delete/start/stop/suspend/resume
 
-
 ## Install Environment
+
 Build the vcenter and ESXi host environment
 
-
 ## Usages
+
 ```
 from hypervisor.virt.esx.powercli import PowerCLI
-
 
 def test_powercli():
     # set up the values

--- a/hypervisor/virt/esx/README.md
+++ b/hypervisor/virt/esx/README.md
@@ -15,7 +15,7 @@ Build the vcenter and ESXi host environment
 
 ## Usages
 
-```
+```python
 from hypervisor.virt.esx.powercli import PowerCLI
 
 def test_powercli():

--- a/hypervisor/virt/esx/README.md
+++ b/hypervisor/virt/esx/README.md
@@ -1,6 +1,6 @@
 # Hypervisor-builder: vCenter
 Hyperivosr-builder tool supports the vcenter hypervisor by PowerCLI Commands following the doc:  
-[VMware vSphere PowerCLI Cmdlets Reference](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/f2319b2a-6378-4635-a1cd-90b14949b62a/0ac4f829-f79b-40a6-ac10-d22ec76937ec/doc/index.html)
+[VMware PowerCLI Documentation](https://developer.vmware.com/powercli/)
 
 
 Provide functions:

--- a/hypervisor/virt/esx/README.md
+++ b/hypervisor/virt/esx/README.md
@@ -1,12 +1,13 @@
 # Hypervisor-builder: vCenter
-Hyperivosr-builder tool supports the vcenter hypervisor by PowerCLI Commands following the doc:  
+Hyperivosr-builder tool supports the vcenter hypervisor by PowerCLI Commands
+following the doc:
 [VMware PowerCLI Documentation](https://developer.vmware.com/powercli/)
 
 
 Provide functions:
-- Collect vcenter information  
+- Collect vcenter information
 - Host search/add/delete/restart/start/stop
-- Guest search/add/delete/start/stop/suspend/resume  
+- Guest search/add/delete/start/stop/suspend/resume
 
 
 ## Install Environment
@@ -39,46 +40,46 @@ def test_powercli():
 
     # Search the specific guest
     msgs = cli.guest_search(guest_name)
-    
+
     # Add a host to be managed by a vCenter Server system.
     cli.host_add("DC-cluster", esx_host, esx_host_user, esx_host_pwd)
-    
+
     # Remove the specified hosts from the inventory.
     cli.host_del(esx_host)
-    
+
     # Check if the esx host exists
     cli.host_exist(esx_host)
-    
+
     # Restart the specified host.
     cli.host_restart(esx_host)
-    
+
     # Search the specific host
     cli.host_search(esx_host)
-    
+
     # Modify the configuration of the host.
     cli.host_set(esx_host, 'Connected')
-    
+
     # Start the specified hosts.
     cli.host_start(esx_host)
-    
+
     # Power off the specified hosts.
     cli.host_stop(esx_host)
 
     # Create a new virtual machine.
     cli.guest_add(esx_host, esx_host_user, esx_host_pwd, guest_name, image_path)
-    
+
     # Remove the specified virtual machines from the vCenter Server system.
     cli.guest_del(guest_name)
-    
+
     # Check if the esx guest exists
     cli.guest_exist(guest_name)
-    
+
     # Power on virtual machines.
     cli.guest_start(guest_name)
-    
+
     # Power off virtual machines.
     cli.guest_stop(guest_name)
-    
+
     # Suspend virtual machines.
     cli.guest_suspend(guest_name)
 ```

--- a/hypervisor/virt/esx/esxapi.py
+++ b/hypervisor/virt/esx/esxapi.py
@@ -2,6 +2,7 @@ import requests
 import json
 from hypervisor import logger
 
+
 # Because the esxapi is not stable, so we use the ssh and PowerCLI to control the esx host
 # Now this file is unused, but we will use it in the future
 class Esxapi:
@@ -9,7 +10,8 @@ class Esxapi:
         self,
         server,
         user,
-        passwd,):
+        passwd,
+    ):
         """
         Collect vcenter information, provide Host add/delete and
         Guest add/delete/start/stop/suspend/resume functions
@@ -20,9 +22,7 @@ class Esxapi:
         self.passwd = passwd
         self.timeout = 5
         self.session_id = requests.post(
-            url=self.server+r'/api/session',
-            auth=(user,passwd),
-            timeout=self.timeout
+            url=self.server + r"/api/session", auth=(user, passwd), timeout=self.timeout
         )
 
     def _format(self, response):
@@ -33,23 +33,19 @@ class Esxapi:
         Get the VMhost info
         :return: the VMHosts info
         """
-        header = {
-            "vmware-api-session-id": self.session_id
-        }
-        
+        header = {"vmware-api-session-id": self.session_id}
+
         response = requests.get(
-            url=self.server+r'/api/vcenter/host',
-            headers=header,
-            timeout=self.timeout
+            url=self.server + r"/api/vcenter/host", headers=header, timeout=self.timeout
         )
-        
+
         output = self._format(response)
-        
+
         for host in output:
             logger.info(f"Get ESXi Host: {host['Name']}")
-        
+
         return output
-    
+
     def guest_add(self):
         """
         Create a new virtual machine.
@@ -61,7 +57,7 @@ class Esxapi:
         :return: create successfully, return True, else, return False
         """
         pass
-    
+
     def guest_exist(self, guest_name):
         """
         Check if the esx guest exists
@@ -69,22 +65,19 @@ class Esxapi:
         :return: guest exists, return True, else, return False.
         """
         # https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/vcenter/VM/
-        header = {
-            "vmware-api-session-id": self.session_id
-        }
-        
+        header = {"vmware-api-session-id": self.session_id}
+
         response = requests.get(
-            url=self.server+r'/api/vcenter/vm/'+guest_name,
+            url=self.server + r"/api/vcenter/vm/" + guest_name,
             headers=header,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
-        
-        if response.status!=200:
+
+        if response.status != 200:
             return False
-        
+
         return True
 
-    
     def guest_search(self, guest_name, uuid_info=False):
         """
         Search the specific guest, return the expected attributes
@@ -94,29 +87,27 @@ class Esxapi:
                  guest_state: guest_poweron:1, guest_poweroff:0, guest_Suspended:2
                  esx_state: host_poweron:1, host_poweroff:0
         """
-        
-        header = {
-            "vmware-api-session-id": self.session_id
-        }
-        
+
+        header = {"vmware-api-session-id": self.session_id}
+
         # https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/vcenter/VM/
         response = requests.get(
-            url=self.server+r'/api/vcenter/vm/'+guest_name,
+            url=self.server + r"/api/vcenter/vm/" + guest_name,
             headers=header,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
         base_output = self._format(response)
-        
+
         # https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/api/vcenter/vm/vm/guest/identity/get/
         response = requests.get(
-            url=self.server+r'/api/vcenter/vm/'+guest_name+r'/guest/identity',
+            url=self.server + r"/api/vcenter/vm/" + guest_name + r"/guest/identity",
             headers=header,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
         id_output = self._format(response)
-        
+
         # host_name = id_output["host_name"]
-        
+
         guest_msgs = {
             "guest_name": base_output["name"],
             "guest_state": base_output["power_state"],
@@ -130,11 +121,11 @@ class Esxapi:
             # "esx_cluster": output["VMHost"]["Parent"],
         }
         # if uuid_info:
-            # guest_msgs["guest_uuid"] = self.guest_uuid(guest_name)
-            # guest_msgs["esx_uuid"] = self.host_uuid(host_name)
-            # guest_msgs["esx_hwuuid"] = self.host_hwuuid(host_name)
+        # guest_msgs["guest_uuid"] = self.guest_uuid(guest_name)
+        # guest_msgs["esx_uuid"] = self.host_uuid(host_name)
+        # guest_msgs["esx_hwuuid"] = self.host_hwuuid(host_name)
         return guest_msgs
-    
+
     def guest_start(self, guest_name):
         """
         Power on virtual machines.
@@ -142,42 +133,38 @@ class Esxapi:
         :return: power on successfully, return True, else, return False.
         """
         # https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/vm/guest.power/
-        header = {
-            "vmware-api-session-id": self.session_id
-        }
-        
+        header = {"vmware-api-session-id": self.session_id}
+
         response = requests.get(
-            url=self.server+r'/api/vcenter/vm/'+guest_name+r'/power?action=start',
+            url=self.server + r"/api/vcenter/vm/" + guest_name + r"/power?action=start",
             headers=header,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
-        
-        if response.status_code==204:
+
+        if response.status_code == 204:
             logger.info("Succeeded to start vcenter guest")
             return True
         else:
             logger.error("Failed to start vcenter guest")
             return False
-    
+
     def guest_stop(self, guest_name):
         # https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/vm/guest.power/
-        header = {
-            "vmware-api-session-id": self.session_id
-        }
-        
+        header = {"vmware-api-session-id": self.session_id}
+
         response = requests.get(
-            url=self.server+r'/api/vcenter/vm/'+guest_name+r'/power?action=stop',
+            url=self.server + r"/api/vcenter/vm/" + guest_name + r"/power?action=stop",
             headers=header,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
-        
-        if response.status_code==204:
+
+        if response.status_code == 204:
             logger.info("Succeeded to stop vcenter guest")
             return True
         else:
             logger.error("Failed to stop vcenter guest")
             return False
-    
+
     def guest_suspend(self, guest_name):
         """
         Suspend virtual machines.
@@ -185,23 +172,24 @@ class Esxapi:
         :return: suspend successfully, return True, else, return False.
         """
         # https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/vm/guest.power/
-        header = {
-            "vmware-api-session-id": self.session_id
-        }
-        
+        header = {"vmware-api-session-id": self.session_id}
+
         response = requests.get(
-            url=self.server+r'/api/vcenter/vm/'+guest_name+r'/power?action=suspend',
+            url=self.server
+            + r"/api/vcenter/vm/"
+            + guest_name
+            + r"/power?action=suspend",
             headers=header,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
-        
-        if response.status_code==204:
+
+        if response.status_code == 204:
             logger.info("Succeeded to suspend vcenter guest")
             return True
         else:
             logger.error("Failed to suspend vcenter guest")
             return False
-    
+
     def guest_resume(self, guest_name):
         """
         Resume virtual machines
@@ -209,17 +197,15 @@ class Esxapi:
         :return: resume successfully, return True, else, return False.
         """
         # https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/vm/guest.power/
-        header = {
-            "vmware-api-session-id": self.session_id
-        }
-        
+        header = {"vmware-api-session-id": self.session_id}
+
         response = requests.get(
-            url=self.server+r'/api/vcenter/vm/'+guest_name+r'/power?action=start',
+            url=self.server + r"/api/vcenter/vm/" + guest_name + r"/power?action=start",
             headers=header,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
-        
-        if response.status_code==204:
+
+        if response.status_code == 204:
             logger.info("Succeeded to resume vcenter guest")
             return True
         else:
@@ -228,28 +214,28 @@ class Esxapi:
 
     def guest_uuid(self):
         pass
-    
+
     # https://developer.vmware.com/apis/vsphere-automation/latest/esx/api/esx/software/get/
     def host_uuid(self):
         pass
-    
+
     def host_hwuuid(self):
         pass
-    
+
     def host_start(self):
         pass
-    
+
     def host_stop(self):
         pass
-    
+
     def host_restart(self):
         pass
-    
+
     def host_name_get(self):
         pass
-    
+
     def host_name_set(self):
         pass
-    
+
     def cluster_name_set(self):
         pass

--- a/hypervisor/virt/esx/linux_powercli.py
+++ b/hypervisor/virt/esx/linux_powercli.py
@@ -37,7 +37,7 @@ class PowerCLI:
             f"-Password {self.admin_passwd};"
         )
         self.ssh = SSHConnect(host=client_server, user=client_user, pwd=client_passwd)
-    
+
     def _format(self, ret=0, stdout=None):
         """
         Convert the json string to python list data
@@ -45,11 +45,11 @@ class PowerCLI:
         :param stdout: output for the execute command
         :return: the list after json.loads
         """
-        stdout = re.sub('\[+[\d+$]', '', stdout)
+        stdout = re.sub("\[+[\d+$]", "", stdout)
         res = re.findall(r"[[][\W\w]+[]]", stdout)[0]
         if ret == 0 and res is not None:
             return json.loads(res)
-    
+
     def info(self):
         """
         Get the VMhost info
@@ -93,9 +93,7 @@ class PowerCLI:
         """
         if self.guest_search(guest_name)["guest_state"] != 1:
             self.guest_stop(guest_name)
-        cmd = (
-            f"pwsh -c '{self.cert} Remove-VM -VM {guest_name} -DeletePermanently -Confirm:$false'"
-        )
+        cmd = f"pwsh -c '{self.cert} Remove-VM -VM {guest_name} -DeletePermanently -Confirm:$false'"
         ret, _ = self.ssh.runcmd(cmd)
         if not ret and not self.guest_exist(guest_name):
             logger.info("Succeeded to delete vcenter guest")

--- a/hypervisor/virt/hyperv/README.md
+++ b/hypervisor/virt/hyperv/README.md
@@ -5,7 +5,7 @@ Hyperivosr-builder tool supports the Hyper-V hypervisor by PowerCLI Commands
 Provide functions:
 - Collect Hyper-V information
 - Host uuid
-- Guest search/add/delete/start/stop/suspend/resume  
+- Guest search/add/delete/start/stop/suspend/resume
 
 
 ## Install Environment
@@ -36,22 +36,22 @@ def test_hypervcli():
 
     # Create a new virtual machine.
     cli.guest_add(guest_name, image_path)
-    
+
     # Remove the specified virtual machines from Hyper-v hypervisor.
     cli.guest_del(guest_name)
-    
+
     # Check if the Hyper-v guest exists
     cli.guest_exist(guest_name)
-    
+
     # Power on virtual machines.
     cli.guest_start(guest_name)
-    
+
     # Power off virtual machines.
     cli.guest_stop(guest_name)
-    
+
     # Suspend virtual machines.
     cli.guest_suspend(guest_name)
-    
+
     # Resume virtual machines
     cli.guest_resume(guest_name)
 ```

--- a/hypervisor/virt/hyperv/README.md
+++ b/hypervisor/virt/hyperv/README.md
@@ -1,21 +1,20 @@
 # Hypervisor-builder: Hyper-V
-Hyperivosr-builder tool supports the Hyper-V hypervisor by PowerCLI Commands
 
+Hyperivosr-builder tool supports the Hyper-V hypervisor by PowerCLI Commands
 
 Provide functions:
 - Collect Hyper-V information
 - Host uuid
 - Guest search/add/delete/start/stop/suspend/resume
 
-
 ## Install Environment
+
 Set up the Hyper-V environment
 
-
 ## Usages
+
 ```
 from hypervisor.virt.hyperv.hypervcli import HypervCLI
-
 
 def test_hypervcli():
     # set up the values

--- a/hypervisor/virt/hyperv/README.md
+++ b/hypervisor/virt/hyperv/README.md
@@ -13,7 +13,7 @@ Set up the Hyper-V environment
 
 ## Usages
 
-```
+```python
 from hypervisor.virt.hyperv.hypervcli import HypervCLI
 
 def test_hypervcli():

--- a/hypervisor/virt/hyperv/hypervcli.py
+++ b/hypervisor/virt/hyperv/hypervcli.py
@@ -261,7 +261,7 @@ class HypervCLI:
         else:
             logger.error("Failed to resume hyperv guest")
             return False
-    
+
     def guest_uuid_change(self, guid, guest_name):
         """
         Change guid for guest
@@ -274,7 +274,7 @@ class HypervCLI:
         if ret:
             logger.error("Failed to create function")
             return False
-        
+
         import_module_cmd = r"Import-Module ./New-VMBIOSGUID.ps1 -Force"
         set_ignore_verfiy_cmd = r"$ConfirmPreference = 'None'"
         change_guid_cmd = f'PowerShell -Command "{set_ignore_verfiy_cmd}; {import_module_cmd}; New-VMBIOSGUID -VM {guest_name} -NewID {guid}"'

--- a/hypervisor/virt/kubevirt/README.md
+++ b/hypervisor/virt/kubevirt/README.md
@@ -1,5 +1,6 @@
 # Hypervisor-builder: KubeVirt
-Hyperivosr-builder tool supports the kubeVirt hypervisor by kubevirt API interfaces following the doc:  
+Hyperivosr-builder tool supports the kubeVirt hypervisor by kubevirt API
+interfaces following the doc:
 [KubeVirt API Reference](http://kubevirt.io/api-reference/)
 
 
@@ -31,17 +32,17 @@ def test_kubevirt():
 
     # Get the VMHost information
     api.get_nodes_list()
-    
+
     # Get the VM information
     vms = api.get_vms()
     vm_info = api.get_vm_info(guest_name)
 
     # Search the specific guest
     msgs = api.guest_search(guest_name, guest_port)
-    
+
     # Power on virtual machines.
     cli.guest_start(guest_name)
-    
+
     # Power off virtual machines.
     cli.guest_stop(guest_name)
 ```

--- a/hypervisor/virt/kubevirt/README.md
+++ b/hypervisor/virt/kubevirt/README.md
@@ -1,23 +1,22 @@
 # Hypervisor-builder: KubeVirt
+
 Hyperivosr-builder tool supports the kubeVirt hypervisor by kubevirt API
 interfaces following the doc:
 [KubeVirt API Reference](http://kubevirt.io/api-reference/)
-
 
 Provide functions:
 - Collect kubevirt node information
 - Collect kubevirt guest information
 - Guest search/start/stop
 
-
 ## Install Environment
+
 Build the kubevirt hypervisor environment
 
-
 ## Usages
+
 ```
 from hypervisor.virt.kubevirt.kubevirtapi import KubevirtApi
-
 
 def test_kubevirt():
     # set up the values

--- a/hypervisor/virt/kubevirt/README.md
+++ b/hypervisor/virt/kubevirt/README.md
@@ -15,7 +15,7 @@ Build the kubevirt hypervisor environment
 
 ## Usages
 
-```
+```python
 from hypervisor.virt.kubevirt.kubevirtapi import KubevirtApi
 
 def test_kubevirt():

--- a/hypervisor/virt/libvirt/README.md
+++ b/hypervisor/virt/libvirt/README.md
@@ -13,7 +13,7 @@ Set up the libvirt environment
 
 ## Usages
 
-```
+```python
 from hypervisor.virt.libvirt.libvirtcli import LibvirtCLI
 
 def test_libevirt():

--- a/hypervisor/virt/libvirt/README.md
+++ b/hypervisor/virt/libvirt/README.md
@@ -1,21 +1,20 @@
 # Hypervisor-builder: Libvirt
-Hyperivosr-builder tool supports the libvirt hypervisor by virsh Commands
 
+Hyperivosr-builder tool supports the libvirt hypervisor by virsh Commands
 
 Provide functions:
 - Collect libvirt information
 - Libvirt host uuid/version/cpu
 - Guest search/start/stop/suspend/resume
 
-
 ## Install Environment
+
 Set up the libvirt environment
 
-
 ## Usages
+
 ```
 from hypervisor.virt.libvirt.libvirtcli import LibvirtCLI
-
 
 def test_libevirt():
     # set up the values

--- a/hypervisor/virt/libvirt/README.md
+++ b/hypervisor/virt/libvirt/README.md
@@ -29,19 +29,19 @@ def test_libevirt():
 
     # Search the specific guest
     msgs = cli.guest_search(guest_name)
-    
+
     # Check if the Hyper-v guest exists
     cli.guest_exist(guest_name)
-    
+
     # Power on virtual machines.
     cli.guest_start(guest_name)
-    
+
     # Power off virtual machines.
     cli.guest_stop(guest_name)
-    
+
     # Suspend virtual machines.
     cli.guest_suspend(guest_name)
-    
+
     # Resume virtual machines.
     cli.guest_resume(guest_name)
 ```

--- a/hypervisor/virt/libvirt/libvirtcli.py
+++ b/hypervisor/virt/libvirt/libvirtcli.py
@@ -246,7 +246,9 @@ class LibvirtCLI:
         cmd = "virsh autostart {0}".format(guest_name)
         ret, output = self.ssh.runcmd(cmd)
         if not ret:
-            logger.info("Succeeded to auto start libvirt({0}) guest".format(self.server))
+            logger.info(
+                "Succeeded to auto start libvirt({0}) guest".format(self.server)
+            )
         else:
             logger.info("Failed to auto start libvirt({0}) guest".format(self.server))
 
@@ -354,7 +356,9 @@ class LibvirtCLI:
             logger.info(f"Succeeded to delete libvirt({self.server}) guest")
             return True
 
-    def guest_image_download(self, guest_name, image_url, xml_url, image_path, xml_path):
+    def guest_image_download(
+        self, guest_name, image_url, xml_url, image_path, xml_path
+    ):
         """
         Download the guest image
         :param guest_name:  the name of guest
@@ -372,8 +376,10 @@ class LibvirtCLI:
         if self.url_validation(xml_url) is False:
             logger.error("xml_url is not available")
         if self.guest_image_exist(guest_name, image_path, xml_path) is False:
-            cmd = f"rm -f {guest_xml}; rm -rf {image_path}; mkdir -p {image_path}; "\
-                  f"chmod a+rwx {image_path}"
+            cmd = (
+                f"rm -f {guest_xml}; rm -rf {image_path}; mkdir -p {image_path}; "
+                f"chmod a+rwx {image_path}"
+            )
             self.ssh.runcmd(cmd)
             for i in range(5):
                 cmd = f"curl -L {image_url} -o {guest_image}"
@@ -387,7 +393,9 @@ class LibvirtCLI:
                 if ret == 0:
                     break
                 logger.warning("Failed to download libvirt xml file, try again...")
-            cmd = f"sed -i -e 's|<name>.*</name>|<name>{guest_name}</name>|g' {guest_xml}"
+            cmd = (
+                f"sed -i -e 's|<name>.*</name>|<name>{guest_name}</name>|g' {guest_xml}"
+            )
             self.ssh.runcmd(cmd)
             cmd = f"sed -i -e 's|<source file=.*/>|<source file=\"{guest_image}\"/>|g' {guest_xml}"
             self.ssh.runcmd(cmd)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,22 @@
 from setuptools import setup
 
 setup(
-    name='hypervisor-builder',
-    version='0.1',
-    packages=['hypervisor', 'hypervisor.virt', 'hypervisor.virt.ahv', 'hypervisor.virt.esx', 'hypervisor.virt.xen', 'hypervisor.virt.rhevm', 'hypervisor.virt.hyperv', 'hypervisor.virt.libvirt', 'hypervisor.virt.kubevirt'],
-    url='https://github.com/VirtwhoQE/hypervisor-builder',
-    license='GPL-3.0',
-    author='',
-    author_email='',
-    description='Library to set up various hypervisors for virt-who testing.'
+    name="hypervisor-builder",
+    version="0.1",
+    packages=[
+        "hypervisor",
+        "hypervisor.virt",
+        "hypervisor.virt.ahv",
+        "hypervisor.virt.esx",
+        "hypervisor.virt.xen",
+        "hypervisor.virt.rhevm",
+        "hypervisor.virt.hyperv",
+        "hypervisor.virt.libvirt",
+        "hypervisor.virt.kubevirt",
+    ],
+    url="https://github.com/VirtwhoQE/hypervisor-builder",
+    license="GPL-3.0",
+    author="",
+    author_email="",
+    description="Library to set up various hypervisors for virt-who testing.",
 )


### PR DESCRIPTION
- Update _connect() and _transfer() methods to fallback to password-based methods when both password and rsa key are None, allowing ssh-agent authentication
- Update pwd_connect() to use ssh-agent when password is None
- Update pwd_transfer() to use ssh-agent when password is None for SFTP
- Update error message to reflect ssh-agent support

This matches the behavior of virtwho-test's SSH class and allows the package to work in environments where ssh-agent is used for authentication.

this also fixes all the megalinter errors